### PR TITLE
typo and suggested change for Answer drop-downs

### DIFF
--- a/content/digital_modulation.rst
+++ b/content/digital_modulation.rst
@@ -33,7 +33,7 @@ Take a moment to try to answer these questions:
 .. raw:: html
 
    <details>
-   <summary><a>Answers</a></summary>
+   <summary>Answers</summary>
 
 1. 250 Mbps - (1/8e-9)*2
 2. Four (which is what ethernet cables have)
@@ -89,7 +89,7 @@ Question: How many symbols are shown in the signal snippet above?  How many bits
 .. raw:: html
 
    <details>
-   <summary><a>Answers</a></summary>
+   <summary>Answers</summary>
 
 20 symbols, so 40 bits of information
 
@@ -167,7 +167,7 @@ Question: What’s wrong with using a PSK scheme like the one in the below image
 .. raw:: html
 
    <details>
-   <summary><a>Answer</a></summary>
+   <summary>Answer</summary>
 
 There is nothing invalid about this PSK scheme. You can certainly use it, but, because the symbols are not uniformly spaced, this scheme is not as effective as it could be. Scheme efficiency will become clear once we discuss how noise impacts our symbols.  The short answer is that we want to leave as much room as possible in between the symbols, in case there is noise, so that a symbol is not interpreted at the receiver as one of the other (incorrect) symbols.  We don't want a 0 being received as a 1.
 

--- a/content/filters.rst
+++ b/content/filters.rst
@@ -239,7 +239,7 @@ Because our filter is not symmetrical around 0 Hz, it has to use complex taps. T
 Filter Implementation
 *************************
 
-We aren't going to dive too deeply into the implementation of filters. Rather, I focus on filter design (you can find read-to-use implementations in any programming language anyway).  For now, here is one take-away:  to filter a signal with an FIR filter, you simply convolve the impulse response (the array of taps) with the input signal.  (Don't worry, a later section explains convolution.) In the discrete world we use a discrete convolution (example below).  The triangles labeled as b's are the taps.  In the flowchart, the squares labeled :math:`z^{-1}` above the triangles signify to delay by one time step.
+We aren't going to dive too deeply into the implementation of filters. Rather, I focus on filter design (you can find ready-to-use implementations in any programming language anyway).  For now, here is one take-away:  to filter a signal with an FIR filter, you simply convolve the impulse response (the array of taps) with the input signal.  (Don't worry, a later section explains convolution.) In the discrete world we use a discrete convolution (example below).  The triangles labeled as b's are the taps.  In the flowchart, the squares labeled :math:`z^{-1}` above the triangles signify to delay by one time step.
 
 .. image:: ../_static/discrete_convolution.png
    :scale: 80 % 
@@ -273,7 +273,7 @@ If you perform a "moving average" across a list of numbers, that's just an FIR f
 .. raw:: html
 
    <details>
-   <summary><a>Answers</a></summary>
+   <summary>Answers</summary>
 
 A moving average filter is a low-pass filter because it smooths out "high frequency" changes, which is usually why people will use one.  The reason to use taps that decay to zero on both ends is to avoid a sudden change in the output, like if the signal being filtered was zero for a while and then suddenly jumped up.
 
@@ -356,7 +356,7 @@ Question: What type of filter was the triangle?
 .. raw:: html
 
    <details>
-   <summary><a>Answers</a></summary>
+   <summary>Answers</summary>
 
 It smoothed out the high frequency components of the green signal (i.e., the sharp transitions of the square) so it acts as a low-pass filter.
 
@@ -402,7 +402,7 @@ The code used to create this filter is fairly simple:
 .. raw:: html
 
    <details>
-   <summary><a>Answer</a></summary>
+   <summary>Answer</summary>
 
 It's not symmetrical around 0 Hz.
 

--- a/content/sync.rst
+++ b/content/sync.rst
@@ -25,7 +25,7 @@ Let's examine Python code for simulating a non-integer delay and a frequency off
 .. raw:: html
 
    <details>
-   <summary><a>Python Code from Pulse Shaping</a></summary>
+   <summary>Python Code from Pulse Shaping</summary>
 
 .. code-block:: python
 
@@ -387,7 +387,7 @@ There is a lot here so let's step through it.  Some lines are simple and others 
 .. raw:: html
 
    <details>
-   <summary><a>Order 4 Costas Loop Error Equation (for those curious)</a></summary>
+   <summary>Order 4 Costas Loop Error Equation (for those curious)</summary>
 
 .. code-block:: python
 


### PR DESCRIPTION
In at least my versions of Chrome, the Answer drop downs only work if the arrow cursor is clicked very precisely, not if the word "Answer" is clicked. This is confusing, especially since "Answer" appears with blue underline as if it can be clicked to open a pop-up or something. For me, I initially concluded clicking on "Answer" just didn't work, but later I did inspection of the html and found out I could bring up the content if my mouse was exactly at the arrow (but nowhere else). If you remove the <a></a> in the <summary></summary> objects, then it works much better. I suggest making this change.

Also, submitting what I think(?) is a minor typo :)