### PR TITLE
Minor CSS width fix for small screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ Feel free to submit an issue, or even a Pull Request (PR) with fixes or improvem
 
 On windows:
 
+```
 sphinx-build -b html -D imgmath_latex="C:\Program Files\MiKTeX 2.9\miktex\bin\x64\latex.exe" . _build
+```
 
 On Ubuntu with *latest* sphinx via apt-get (3.2.1 at the time of this writing) installed with pip, I had to add ~/.local/bin to PATH, and apt-get install texlive-latex-extra:
 
+```bash
 sphinx-build -b html . _build
+```
 
 ## Misc
 

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -91,4 +91,9 @@ div.sphinxsidebar {
     color: purple;
 }
 
-
+/* See https://github.com/bitprophet/alabaster/issues/139 */
+div.body {
+    min-width: auto;
+    max-width: auto;
+    overflow: scroll;
+}


### PR DESCRIPTION
First off thanks for the textbook! I'm finding it to be a great learning resource.

I noticed on smaller screens (e.g. phones) that the page had no padding on the right and required scroll out on load to view the whole content. This fixes that by integrating the suggestions from https://github.com/bitprophet/alabaster/issues/139 (there should be no change on screens larger than alabaster's hardcoded 450px)