### PR TITLE
corrected unit of angular frequency

### DIFF
--- a/content/frequency_domain.rst
+++ b/content/frequency_domain.rst
@@ -117,7 +117,7 @@ To return to the time domain from frequency is almost the same, aside from a sca
 .. math::
    x(t) = \frac{1}{2 \pi} \int X(f) e^{j2\pi ft} df
 
-Note that a lot of textbooks and other resources use :math:`w` in place of the :math:`2\pi f`.  :math:`w` is angular frequency in radians, while :math:`f` is in Hz.  All you have to know is that
+Note that a lot of textbooks and other resources use :math:`w` in place of the :math:`2\pi f`.  :math:`w` is angular frequency in radians per second, while :math:`f` is in Hz.  All you have to know is that
 
 .. math::
    \omega = 2 \pi f


### PR DESCRIPTION
`w` has the unit radians per second; As Hz is 1/s not mentioning the per second for `w` would be confusing.