### PR TITLE
iq_files.rst: update sigmf validate

### DIFF
--- a/content/iq_files.rst
+++ b/content/iq_files.rst
@@ -202,7 +202,7 @@ The Python code to write the .sigmf-meta file for the example towards the beginn
  })
  
  # check for mistakes and write to disk
- assert meta.validate()
+ meta.validate()
  meta.tofile('bpsk_in_noise.sigmf-meta') # extension is optional
 
 Simply replace :code:`8000000` and :code:`915000000` with the variables you used to store sample rate and center frequency respectively. 


### PR DESCRIPTION
`assert meta.validate` will fail because this function returns None on success. Perhaps it used to return True/False, but currently the main branch states that it returns None and asserts on error.

This change updates the sigmf example to that style.

https://github.com/sigmf/sigmf-python/blob/main/sigmf/validate.py#L66